### PR TITLE
Comment out unused imports (and remove an unnecessary cast)

### DIFF
--- a/src/main/java/com/team1389/robot/Robot.java
+++ b/src/main/java/com/team1389/robot/Robot.java
@@ -6,7 +6,7 @@ import com.team1389.auto.AutoModeExecuter;
 import com.team1389.hardware.outputs.hardware.CANTalonHardware;
 import com.team1389.hardware.registry.Registry;
 import com.team1389.operation.TeleopMain;
-import com.team1389.system.drive.FourWheelSignal;
+//import com.team1389.system.drive.FourWheelSignal;
 import com.team1389.watchers.DashboardInput;
 
 import edu.wpi.first.wpilibj.IterativeRobot;

--- a/src/main/java/com/team1389/robot/RobotHardware.java
+++ b/src/main/java/com/team1389/robot/RobotHardware.java
@@ -5,9 +5,9 @@ import com.team1389.hardware.inputs.hardware.SpartanGyro;
 import com.team1389.hardware.outputs.hardware.CANTalonHardware;
 import com.team1389.hardware.outputs.hardware.VictorHardware;
 import com.team1389.hardware.registry.Registry;
-import com.team1389.hardware.registry.port_types.SPIPort;
+//import com.team1389.hardware.registry.port_types.SPIPort;
 
-import edu.wpi.first.wpilibj.SPI.Port;
+//import edu.wpi.first.wpilibj.SPI.Port;
 
 /**
  * responsible for initializing and storing hardware objects defined in

--- a/src/main/java/com/team1389/watchers/DashboardInput.java
+++ b/src/main/java/com/team1389/watchers/DashboardInput.java
@@ -41,7 +41,7 @@ public class DashboardInput {
 				break;
 			}
 		}
-		selectedOption = (AutonOption) autonSelector.getSelected();
+		selectedOption = autonSelector.getSelected();
 		return AutonModeSelector.createAutoMode(selectedOption);
 	}
 


### PR DESCRIPTION
Not only is it good practice, but it also declutters the Problems view in Eclipse.